### PR TITLE
Replace only the scheme part of the URL.

### DIFF
--- a/flask_sslify.py
+++ b/flask_sslify.py
@@ -43,10 +43,11 @@ class SSLify(object):
         ]
 
         if not any(criteria):
-            url = request.url.replace('http://', 'https://')
-            r = redirect(url)
+            if request.url.startswith('http://'):
+                url = request.url.replace('http://', 'https://', 1)
+                r = redirect(url)
 
-            return r
+                return r
 
     def set_hsts_header(self, response):
         """Adds HSTS header to each response."""


### PR DESCRIPTION
This prevents accidental rewrites of any HTTP URLs in query string
parameters, like for example:

```
http://localhost/translate?src=http://non-secure-site.org/
```
