### PR TITLE
Add USE_SSL Flask config variable to turn on/off SSL instead of only app.debug

### DIFF
--- a/flask_sslify.py
+++ b/flask_sslify.py
@@ -36,9 +36,15 @@ class SSLify(object):
     def redirect_to_ssl(self):
         """Redirect incoming requests to HTTPS."""
         # Should we redirect?
+
+        # Use Flask config variable USE_SSL
+        use_ssl = app.config.get('USE_SSL', None)
+        if use_ssl is None:
+            use_ssl = not (self.app.debug)
+
         criteria = [
             request.is_secure,
-            self.app.debug,
+            not (use_ssl),
             request.headers.get('X-Forwarded-Proto', 'http') == 'https'
         ]
 


### PR DESCRIPTION
Proposing adding some sort of Flask config variable/flag to force SSL redirect on or off. I think this is useful for a case where you have a staging server, where you might want SSL but want to also have debug enabled, for debugging server exceptions.

If USE_SSL is not defined, default to the previous logic of looking at app.debug
