### PR TITLE
 Updated extension to support the preload flag in HSTS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,14 @@ If you'd like to include subdomains in your HSTS policy, set the ``subdomains`` 
 
 Or by including ``SSLIFY_SUBDOMAINS`` in your app's config.
 
+If you'd like to include the preload flag in your HSTS policy, set the ``preload`` parameter::
+
+    sslify = SSLify(app, preload=True)
+
+
+Or by including ``SSLIFY_PRELOAD`` in your app's config. The preload flag is required if submitting
+an HSTS enabled domain to Chrome's HSTS preload list.
+
 
 HTTP 301 Redirects
 ------------------
@@ -64,7 +72,7 @@ Or by including ``SSLIFY_PERMANENT`` in your app's config.
 Exclude Certain Paths from Being Redirected
 -------------------------------------------
 You can exlude a path that starts with given string by including a list called ``skips``::
- 
+
      sslify = SSLify(app, skips=['mypath', 'anotherpath'])
 
 Or by including ``SSLIFY_SKIPS`` in your app's config.
@@ -76,8 +84,8 @@ Install
 Installation is simple too::
 
     $ pip install Flask-SSLify
-    
-    
+
+
 Security consideration using basic auth
 ---------------------------------------
 

--- a/flask_sslify.py
+++ b/flask_sslify.py
@@ -8,7 +8,7 @@ YEAR_IN_SECS = 31536000
 class SSLify(object):
     """Secures your Flask App."""
 
-    def __init__(self, app=None, age=YEAR_IN_SECS, subdomains=False, permanent=False, skips=None):
+    def __init__(self, app=None, age=YEAR_IN_SECS, subdomains=False, permanent=False, skips=None, preload=False):
         self.app = app or current_app
         self.hsts_age = age
 
@@ -19,6 +19,7 @@ class SSLify(object):
         self.hsts_include_subdomains = subdomains or self.app.config['SSLIFY_SUBDOMAINS']
         self.permanent = permanent or self.app.config['SSLIFY_PERMANENT']
         self.skip_list = skips or self.app.config['SSLIFY_SKIPS']
+        self.hsts_include_preload = preload or self.app.config['SSLIFY_PRELOAD']
 
         if app is not None:
             self.init_app(app)
@@ -35,6 +36,9 @@ class SSLify(object):
 
         if self.hsts_include_subdomains:
             hsts_policy += '; includeSubDomains'
+
+        if self.hsts_include_preload:
+            hsts_policy += '; preload'
 
         return hsts_policy
 


### PR DESCRIPTION
Hi Kenneth, I've updated the flask extension to support the preload flag which is a requirement[1] by the Chromium team if one wishes to submit an HSTS enabled domain to Chrome's preload list.

[1] https://hstspreload.appspot.com
