### PR TITLE
Support regexes in skip list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+flask_sslify.pyc

--- a/README.rst
+++ b/README.rst
@@ -63,9 +63,11 @@ Or by including ``SSLIFY_PERMANENT`` in your app's config.
 
 Exclude Certain Paths from Being Redirected
 -------------------------------------------
-You can exlude a path that starts with given string by including a list called ``skips``::
- 
-     sslify = SSLify(app, skips=['mypath', 'anotherpath'])
+You can exlude a path that starts with given string or matches a regex
+by including a list called ``skips``::
+
+    import re
+    sslify = SSLify(app, skips=['mypath', 'anotherpath', re.compile('^/foo/\w*/bar')])
 
 Or by including ``SSLIFY_SKIPS`` in your app's config.
 

--- a/flask_sslify.py
+++ b/flask_sslify.py
@@ -42,10 +42,16 @@ class SSLify(object):
     def skip(self):
         """Checks the skip list."""
         # Should we skip?
-        if self.skip_list and isinstance(self.skip_list, list): 
+        if self.skip_list and isinstance(self.skip_list, list):
             for skip in self.skip_list:
-                if request.path.startswith('/{0}'.format(skip)):
-                    return True
+                if hasattr(skip, 'format'):
+                    # accept 'skip' with or without leading '/'
+                    if (request.path.startswith('/{0}'.format(skip))
+                            or request.path.startswith(skip)):
+                        return True
+                elif hasattr(skip, 'match'):
+                    if skip.match(request.path):
+                        return True
         return False
 
     def redirect_to_ssl(self):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 setup(
     name='Flask-SSLify',
-    version='0.1.5',
+    version='0.1.6',
     url='https://github.com/kennethreitz/flask-sslify',
     license='BSD',
     author='Kenneth Reitz',


### PR DESCRIPTION
The motivation for this is that I want to skip '/' and '/api/_' but not '/admin/_'.

Example usage:

```
import re
....
sslify = SSLify(app, skips=[re.compile('^/$'), 'api'])
```
