### PR TITLE
Disable redirects when testing mode is enabled.

### DIFF
--- a/flask_sslify.py
+++ b/flask_sslify.py
@@ -42,7 +42,7 @@ class SSLify(object):
     def skip(self):
         """Checks the skip list."""
         # Should we skip?
-        if self.skip_list and isinstance(self.skip_list, list): 
+        if self.skip_list and isinstance(self.skip_list, list):
             for skip in self.skip_list:
                 if request.path.startswith('/{0}'.format(skip)):
                     return True
@@ -54,6 +54,7 @@ class SSLify(object):
         criteria = [
             request.is_secure,
             current_app.debug,
+            current_app.testing,
             request.headers.get('X-Forwarded-Proto', 'http') == 'https'
         ]
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 setup(
     name='Flask-SSLify',
-    version='0.1.5',
+    version='0.1.6',
     url='https://github.com/kennethreitz/flask-sslify',
     license='BSD',
     author='Kenneth Reitz',


### PR DESCRIPTION
This change modifies the criteria for redirection of requests to include the `app.testing` flag, generally set during testing of a Flask app. This is very useful because the Flask `test_client` does not follow redirects, so enabling the redirects during testing means that the test requests will fail. 
