### PR TITLE
Add a note about Flask-Talisman

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@ Flask-SSLify
 This is a simple Flask extension that configures your Flask application to redirect
 all incoming requests to HTTPS.
 
+The extension is no longer maintained, prefer using `Flask-Talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_ as it is encouraged by the `Flask Security Guide <http://flask.pocoo.org/docs/dev/security/>`_.
+
 If you're interested in financially supporting Kenneth Reitz open source, consider `visiting this link <https://cash.me/$KennethReitz>`_. Your support helps tremendously with sustainability of motivation, as Open Source is no longer part of my day job.
 
 Redirects only occur when ``app.debug`` is ``False``.


### PR DESCRIPTION
A lot of time has passed since @kennethreitz took care of the extension but it still shows up at the top of Google SERP for anything related to Flask and HTTPS.

In the meanwhile, I found out that [Flask's own security guide](http://flask.pocoo.org/docs/dev/security/) recommends to use Talisman, which is pretty good and well-maintained.